### PR TITLE
feat(summary): show isolation side per step in Winding Construction Steps

### DIFF
--- a/src/components/Toolbox/MagneticSummary.vue
+++ b/src/components/Toolbox/MagneticSummary.vue
@@ -354,7 +354,8 @@ export default {
                             description: thickness && thickness.label > 0
                                 ? `Apply ${material} (${removeTrailingZeroes(thickness.label, 2)} ${thickness.unit})` 
                                 : `Apply ${material}`,
-                            icon: 'bi-record-circle'
+                            icon: 'bi-record-circle',
+                            isolation: null
                         });
                     } else if (layerType === 'conduction') {
                         const partialWinding = layer.partialWindings?.[0];
@@ -392,7 +393,8 @@ export default {
                             step: stepNum++,
                             type: 'winding',
                             description: `Wind ${toTitleCase(windingName)}: ${turnsDisplay} turns${parallelInfo}${wireDesc}`,
-                            icon: 'bi-arrow-repeat'
+                            icon: 'bi-arrow-repeat',
+                            isolation: winding?.isolationSide ? toTitleCase(winding.isolationSide) : null
                         });
                     }
                 });
@@ -407,7 +409,8 @@ export default {
                             step: stepNum++,
                             type: 'insulation',
                             description: 'Apply insulation layer',
-                            icon: 'bi-record-circle'
+                            icon: 'bi-record-circle',
+                            isolation: null
                         });
                     } else if (sectionType === 'conduction') {
                         const partialWinding = section.partialWindings?.[0];
@@ -419,7 +422,8 @@ export default {
                             step: stepNum++,
                             type: 'winding',
                             description: `Wind ${toTitleCase(windingName)}: ${totalTurns} turns`,
-                            icon: 'bi-arrow-repeat'
+                            icon: 'bi-arrow-repeat',
+                            isolation: winding?.isolationSide ? toTitleCase(winding.isolationSide) : null
                         });
                     }
                 });
@@ -970,6 +974,9 @@ export default {
                             <i :class="'bi ' + step.icon"></i>
                         </div>
                         <div class="step-description">{{ step.description }}</div>
+                        <div v-if="step.isolation" class="step-isolation" :title="'Isolation side: ' + step.isolation">
+                            <i class="bi bi-shield-fill"></i>{{ step.isolation }}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -1375,6 +1382,21 @@ export default {
 .step-description {
     font-size: 11px;
     color: var(--p-white);
+}
+
+.step-isolation {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 600;
+    color: rgb(var(--p-info-rgb));
+    background: rgba(var(--p-info-rgb), 0.12);
+    border-radius: 10px;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 /* Operating Point Excitation */


### PR DESCRIPTION
## Summary
Adds a read-only **Isolation** badge to each step in the Magnetic Summary's **Winding Construction Steps**. Winding steps show that winding's isolation side (Primary / Secondary / …); insulation steps (barriers between sides) show none.

Derived entirely from `coil.functionalDescription[w].isolationSide` — no new data, and `isolationSide` stays editable only in Design Requirements (read-only here).

## Before / After
Interleaved transformer (`1-2` = Primary, `3-4` = Secondary):

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/gpitel/WebFrontend/assets/pr-isolation/pr-assets/isolation-before.png) | ![after](https://raw.githubusercontent.com/gpitel/WebFrontend/assets/pr-isolation/pr-assets/isolation-after.png) |

## Validation
Headless Playwright check: 12 construction steps — 6 winding steps badged Primary/Secondary, 6 insulation steps unbadged. HMR-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge order / dependencies
No cross-repo dependencies.

Note: #22 touches the same file (`MagneticSummary.vue`); whichever merges second needs a trivial rebase.