### PR TITLE
feat(summary): add Winding Termination section to the magnetic summary

### DIFF
--- a/src/components/Toolbox/MagneticSummary.vue
+++ b/src/components/Toolbox/MagneticSummary.vue
@@ -427,6 +427,34 @@ export default {
             
             return steps;
         },
+        windingTerminations() {
+            const windings = this.mas?.magnetic?.coil?.functionalDescription || [];
+            // One step per connection, grouped by winding (in functionalDescription
+            // order): "Start of"/"End of" <winding> to <type> <pin>, e.g. "Start of Primary to Pin 3".
+            const result = [];
+            windings.forEach((winding, index) => {
+                const name = toTitleCase(winding.name?.toLowerCase() || `Winding ${index + 1}`);
+                const connections = winding?.connections || [];
+                connections.forEach((c, ci) => {
+                    const type = c.type || 'Pin';
+                    const pin = (c.pinName != null && c.pinName !== '') ? c.pinName : '?';
+                    // Connections are ordered start-then-finish: the first is the
+                    // winding's start lead, the last is its end lead.
+                    let prefix = '';
+                    if (ci === 0) {
+                        prefix = 'Start of ';
+                    } else if (ci === connections.length - 1) {
+                        prefix = 'End of ';
+                    }
+                    result.push({
+                        step: result.length + 1,
+                        description: `${prefix}${name} to ${type} ${pin}`,
+                        icon: 'bi-plug-fill'
+                    });
+                });
+            });
+            return result;
+        },
         performanceData() {
             const data = [];
             const outputs = this.mas?.outputs?.[0];
@@ -974,6 +1002,21 @@ export default {
                 </div>
             </div>
 
+            <!-- Winding Termination -->
+            <div class="section" v-if="isWoundMagnetic && windingTerminations.length > 0">
+                <h3 class="section-title"><i class="pi pi-link"></i>Winding Termination</h3>
+                <div class="construction-steps">
+                    <div v-for="step in windingTerminations" :key="step.step"
+                         class="construction-step step-connection">
+                        <div class="step-number">{{ step.step }}</div>
+                        <div class="step-icon">
+                            <i :class="'bi ' + step.icon"></i>
+                        </div>
+                        <div class="step-description">{{ step.description }}</div>
+                    </div>
+                </div>
+            </div>
+
             <div class="document-footer">
                 <i class="pi pi-info-circle"></i>
                 <span>Auto-generated from design specs and simulation. Verify before production use.</span>
@@ -1341,6 +1384,11 @@ export default {
 .construction-step.step-winding {
     background: rgba(var(--p-primary-rgb), 0.1);
     border-left-color: var(--p-primary);
+}
+
+.construction-step.step-connection {
+    background: rgba(var(--p-success-rgb), 0.1);
+    border-left-color: rgb(var(--p-success-rgb));
 }
 
 .step-number {


### PR DESCRIPTION
## Summary
Adds a **Winding Termination** section to the Magnetic Summary, after the Winding Construction Steps. One read-only entry per connection, grouped by winding (`functionalDescription` order); start-then-finish, so each names whether it is the start or end of the winding, the terminal type, and the pin — e.g. *"Start of Primary to Pin 3"* / *"End of Primary to Pin 4"*. Derived from `coil.functionalDescription[w].connections`.

Styled with current PrimeVue tokens (`--p-success-rgb`) and Bootstrap Icons (`bi-plug-fill`).

## Before / After
Magnetic Summary bottom — `main` (Construction Steps flow into the footer) vs this PR, which inserts a new **Winding Termination** section:

| Before (main) | After (this PR) |
|---|---|
| ![before](https://raw.githubusercontent.com/gpitel/WebFrontend/assets/pr-termination/pr-assets/term-before.png) | ![after](https://raw.githubusercontent.com/gpitel/WebFrontend/assets/pr-termination/pr-assets/term-after.png) |

_Screenshots captured on the pre-refactor theme; the section is unchanged — only the accent color follows the current theme._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge order / dependencies
No hard dependencies - the new section is guarded (`v-if` on wound magnetic + terminations present), so it stays hidden until windings have `connections`.

Nothing in the app populates `connections` today; the section starts showing data once OpenMagnetics/MagneticBuilderApp#4 (pin/connection editor) is merged and the `MagneticBuilder` submodule pin is bumped.

Note: #21 touches the same file; whichever merges second needs a trivial rebase.