### PR TITLE
feat(design-requirements): default winding names to 'Winding N' and use them as row labels

### DIFF
--- a/src/components/Toolbox/DesignRequirements.vue
+++ b/src/components/Toolbox/DesignRequirements.vue
@@ -116,7 +116,7 @@ export default {
                 newElementsCoil.push(this.masStore.mas.magnetic.coil.functionalDescription[i]);
             }
             else {
-                newElementsCoil.push({'name': toTitleCase(isolationSideOrdered[i])});
+                newElementsCoil.push({'name': 'Winding ' + (i + 1)});
             }
         }
     },
@@ -168,7 +168,7 @@ export default {
                         newElementsCoil.push(this.masStore.mas.magnetic.coil.functionalDescription[i]);
                     }
                     else {
-                        newElementsCoil.push({'name': toTitleCase(isolationSideOrdered[i])});
+                        newElementsCoil.push({'name': 'Winding ' + (i + 1)});
                     }
                 }
                 for (var operationPointIndex = 0; operationPointIndex < this.masStore.mas.inputs.operatingPoints.length; operationPointIndex++) {

--- a/src/components/Toolbox/DesignRequirements/ArrayElementFromList.vue
+++ b/src/components/Toolbox/DesignRequirements/ArrayElementFromList.vue
@@ -2,7 +2,6 @@
 import { useMasStore } from '../../../stores/mas'
 import { toTitleCase, getMultiplier, combinedStyle, combinedClass } from 'WebSharedComponents/assets/js/utils.js'
 import ElementFromList from 'WebSharedComponents/DataInput/ElementFromList.vue'
-import { isolationSideOrdered } from 'WebSharedComponents/assets/js/defaults.js'
 </script>
 
 <script>
@@ -163,7 +162,7 @@ export default {
                 v-model="masStore.mas.inputs.designRequirements[name]"
                 :options="options"
                 :optionLabels="optionLabels"
-                :replaceTitle="isolationSideOrdered[requirementIndex - 1]"
+                :replaceTitle="(masStore.mas.magnetic.coil.functionalDescription[requirementIndex - 1]?.name ?? ('Winding ' + requirementIndex))"
                 :labelWidthProportionClass="labelWidthProportionClass"
                 :selectStyleClass="selectStyleClass"
                 :labelFontSize='valueFontSize'


### PR DESCRIPTION
## Problem

In the Design Requirements editor, winding rows were labeled with the isolation-side ordinals (Primary, Secondary, …). In the **Isolation Sides** section the left column then repeated the dropdown's vocabulary, so a row read like a contradiction — e.g. *"Secondary → Primary."* The default winding **name** was itself "Primary/Secondary", which collides with the isolation-side tags.

## Fix

1. **Default winding names to `Winding 1/2/3`** instead of the isolation-side ordinals. Windings added via the winding-count control are named `Winding N`; the initial design templates are handled by the companion PR **OpenMagnetics/WebSharedComponents#9**.
2. **Label the Isolation Sides rows with the winding *name*** (editable — the same string the Turns Ratios rows already use) instead of `isolationSideOrdered`.

Net result: winding labels are consistent across Turns Ratios and Isolation Sides, they're editable, and a row reads unambiguously — *"Winding 2 → Primary."* The `isolationSide` enum values are unchanged (still the dropdown options).

## Before / After

**Before** — left column repeats the isolation-group vocabulary:

![before](https://github.com/user-attachments/assets/c0625dd9-b5d2-4880-a2d4-d11debfb2154)

**After** — left column identifies the winding (`Winding N`):

![after](https://github.com/user-attachments/assets/0fec550b-95db-40aa-9497-c767edb8ea63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge order / dependencies
Soft dependency: OpenMagnetics/WebSharedComponents#9 provides the `Winding N` defaults these labels come from - merge it first (and bump the `WebSharedComponents` submodule pin) so new designs match. Without it nothing breaks; labels just show the existing names (Primary/Secondary).

Note: overlaps #24 in `DesignRequirements.vue` / `ArrayElementFromList.vue`; suggest merging this one first.