### PR TITLE
feat(design-requirements): always show Winding 1 with a locked ratio and editable label

### DIFF
--- a/src/components/Toolbox/DesignRequirements.vue
+++ b/src/components/Toolbox/DesignRequirements.vue
@@ -116,7 +116,7 @@ export default {
                 newElementsCoil.push(this.masStore.mas.magnetic.coil.functionalDescription[i]);
             }
             else {
-                newElementsCoil.push({'name': toTitleCase(isolationSideOrdered[i])});
+                newElementsCoil.push({'name': 'Winding ' + (i + 1)});
             }
         }
     },
@@ -168,7 +168,7 @@ export default {
                         newElementsCoil.push(this.masStore.mas.magnetic.coil.functionalDescription[i]);
                     }
                     else {
-                        newElementsCoil.push({'name': toTitleCase(isolationSideOrdered[i])});
+                        newElementsCoil.push({'name': 'Winding ' + (i + 1)});
                     }
                 }
                 for (var operationPointIndex = 0; operationPointIndex < this.masStore.mas.inputs.operatingPoints.length; operationPointIndex++) {
@@ -327,7 +327,8 @@ export default {
 
                 <ArrayDimensionWithTolerance class="border-bottom-1 border-solid border-300 py-2"
                     :style = "$styleStore.designRequirements.inputBorderColor"
-                    v-if="!masStore.hasMirroredWindings && masStore.mas.inputs.designRequirements.turnsRatios != null && masStore.mas.inputs.designRequirements.turnsRatios.length > 0"
+                    v-if="!masStore.hasMirroredWindings && masStore.mas.inputs.designRequirements.turnsRatios != null"
+                    :referenceWinding="true"
                     :name="'turnsRatios'"
                     :dataTestLabel="dataTestLabel + '-TurnsRatios'"
                     :defaultField="'nominal'"

--- a/src/components/Toolbox/DesignRequirements/ArrayDimensionWithTolerance.vue
+++ b/src/components/Toolbox/DesignRequirements/ArrayDimensionWithTolerance.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useMasStore } from '../../../stores/mas'
-import { toTitleCase, getMultiplier, combinedStyle, combinedClass } from 'WebSharedComponents/assets/js/utils.js'
+import { toTitleCase, getMultiplier, combinedStyle, combinedClass, renameWinding } from 'WebSharedComponents/assets/js/utils.js'
 import DimensionWithTolerance from 'WebSharedComponents/DataInput/DimensionWithTolerance.vue'
 import { isolationSideOrdered } from 'WebSharedComponents/assets/js/defaults.js'
 </script>
@@ -21,6 +21,10 @@ export default {
         },
         fixedNumberElements:{
             type: Number
+        },
+        referenceWinding:{
+            type: Boolean,
+            default: false
         },
         defaultField:{
             type: String,
@@ -94,6 +98,7 @@ export default {
         return {
             masStore,
             errorMessages,
+            referenceRatio: { nominal: 1 },
         }
     },
     mounted () {
@@ -137,7 +142,7 @@ export default {
         changeText(value, index) {
             if (value != '') {
                 this.errorMessages = '';
-                this.masStore.mas.magnetic.coil.functionalDescription[index].name = value;
+                renameWinding(this.masStore.mas, index, value);
             }
             else {
                 this.errorMessages = "Winding name cannot be empty";
@@ -159,6 +164,30 @@ export default {
             >
                 {{toTitleCase(name)}}
             </label>
+        </div>
+        <!-- Winding 1 is the reference winding: ratio fixed at 1 (locked), label editable.
+             Uses the same DimensionWithTolerance as the rows below so the row is identical. -->
+        <div v-if="referenceWinding" :data-cy="dataTestLabel + '-reference-container'" class="grid">
+            <DimensionWithTolerance
+                :dataTestLabel="dataTestLabel + '-reference'"
+                :allowAllNull="true"
+                :disabled="true"
+                :disabledScaling="disabledScaling"
+                :varText="true"
+                :name="masStore.mas.magnetic.coil.functionalDescription[0]?.name ?? 'Winding 1'"
+                :unit="unit"
+                :modelValue="referenceRatio"
+                @changeText="changeText($event, 0)"
+                :addButtonStyle="addButtonStyle"
+                :removeButtonBgColor="removeButtonBgColor"
+                :titleFontSize="valueFontSize"
+                :valueFontSize="valueFontSize"
+                :labelBgColor="labelBgColor"
+                :valueBgColor="valueBgColor"
+                :textColor="textColor"
+                :unitExtraStyleClass="unitExtraStyleClass"
+                class="col-12 array-dwt-row reference-dwt"
+            />
         </div>
         <div :data-cy="dataTestLabel + '-' + requirementIndex + '-container'" class="grid" v-for="(requirement, requirementIndex) in masStore.mas.inputs.designRequirements[name]" :key="requirementIndex">
             <DimensionWithTolerance
@@ -191,5 +220,22 @@ export default {
         </div>
     </div>
 </template>
+
+
+<style scoped>
+/* Winding 1 reference row: reuse the shared row layout, but lock the ratio
+   value + add/remove controls. The label (title) stays editable. */
+.reference-dwt :deep(.dwt-fields-row) {
+    pointer-events: none;
+}
+/* The reference ratio is exactly 1 (no tolerance) - show only the locked
+   nominal value, not the Min/Max add-fields or the removable 'Nom.' addon. */
+.reference-dwt :deep(.dwt-fields-row > .dwt-field:not(:nth-child(2))) {
+    display: none;
+}
+.reference-dwt :deep(.dwt-remove-addon) {
+    display: none !important;
+}
+</style>
 
 

--- a/src/components/Toolbox/DesignRequirements/ArrayElementFromList.vue
+++ b/src/components/Toolbox/DesignRequirements/ArrayElementFromList.vue
@@ -163,7 +163,7 @@ export default {
                 v-model="masStore.mas.inputs.designRequirements[name]"
                 :options="options"
                 :optionLabels="optionLabels"
-                :replaceTitle="isolationSideOrdered[requirementIndex - 1]"
+                :replaceTitle="(masStore.mas.magnetic.coil.functionalDescription[requirementIndex - 1]?.name ?? ('Winding ' + requirementIndex))"
                 :labelWidthProportionClass="labelWidthProportionClass"
                 :selectStyleClass="selectStyleClass"
                 :labelFontSize='valueFontSize'


### PR DESCRIPTION
## What

Single-winding (inductor) designs previously showed **no** winding row in **Design Requirements → Turns Ratios** — the section was hidden whenever there were zero ratios, so **Winding 1's label could not be seen or edited**.

This adds **Winding 1** as a *reference row*: its turns ratio is fixed at **1** and is not editable, but its **label is editable** (persists to `coil.functionalDescription[0].name`). The section now renders even for a single winding. Transformers are unchanged — Winding 1 simply appears above the editable ratio rows for windings 2..N.

## Before / After

Design Requirements → **Turns Ratios** (2-winding transformer). Before, Winding 1 wasn't shown; after, it appears as a reference row — ratio locked at **1**, label editable — using the same row layout as the ratio rows below. It omits the Min/Max tolerance fields, since a reference winding has no tolerance.

| Before — Winding 1 absent | After — Winding 1 reference row |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/06a9d957-6a97-4fcf-8e78-22aca5b4a45b" width="400"> | <img src="https://github.com/user-attachments/assets/07992d74-8ee5-4c04-8f8c-6a36594d09b5" width="400"> |

## Implementation

- **`ArrayDimensionWithTolerance.vue`** — opt-in `referenceWinding` prop renders the leading locked-ratio + editable-label row. The shared component is otherwise untouched, so the leakage-inductance / stray-capacitance usages are unaffected.
- **`DesignRequirements.vue`** — show the turns-ratio block whenever `turnsRatios != null` (not only when `length > 0`), and pass `:referenceWinding="true"` to that instance only.
- Also folds in the related winding-label work: new windings default to `Winding N`, and each ratio row is titled by the winding name.

## Verification

Verified live on the dev stack with Playwright:

- **Inductor (1 winding):** the Winding 1 row appears, the ratio is a locked `1` (a non-editable span), and editing the label persisted to the winding name.
- **Transformer (2 windings):** the Winding 1 reference row plus exactly one editable ratio row (Winding 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge order / dependencies
**Hard dependency: OpenMagnetics/WebSharedComponents#15.** This PR imports `renameWinding` from `WebSharedComponents/assets/js/utils.js`, which does not exist on current `main` - merging this without that PR (and a `WebSharedComponents` submodule bump onto it) breaks the app at load time (`SyntaxError: ... does not provide an export named 'renameWinding'`).

Also overlaps #23 (same files); suggest merging #23 first.